### PR TITLE
Fix duplicate chat tree panel

### DIFF
--- a/HistorTreeNodes.js
+++ b/HistorTreeNodes.js
@@ -1,5 +1,6 @@
 const dragable = true;
 const savedPos = localStorage.getItem('chatTreePos');
+let chatTreeObserver = null;
 
 
 document.addEventListener('dragstart', (e) => {
@@ -37,15 +38,17 @@ function repeater() {
     }, 200); // ⏱️ Adjust as needed
 
     // Reload tree when navigating to a new conversation
-    const observer = new MutationObserver(() => {
-        const alreadyInjected = document.getElementById('chat-tree-panel');
-        const chatReady = document.querySelector('[data-testid^="conversation-turn-"]');
-        if (chatReady && !alreadyInjected) {
-            getNodes();
-        }
-    });
+    if (!chatTreeObserver) {
+        chatTreeObserver = new MutationObserver(() => {
+            const alreadyInjected = document.getElementById('chat-tree-panel');
+            const chatReady = document.querySelector('[data-testid^="conversation-turn-"]');
+            if (chatReady && !alreadyInjected) {
+                getNodes();
+            }
+        });
 
-    observer.observe(document.body, { childList: true, subtree: true });
+        chatTreeObserver.observe(document.body, { childList: true, subtree: true });
+    }
 
 }
 
@@ -265,6 +268,8 @@ function getNodes() {
       });
 
       // ⬇️ Inject OFFSCREEN (still inert)
+      const existingPanel = document.getElementById('chat-tree-panel');
+      if (existingPanel) existingPanel.remove();
       document.body.appendChild(root);
 
       // 🧠 Optional: Drag init

--- a/main.js
+++ b/main.js
@@ -35,6 +35,7 @@ const pauseButton = document.createElement('button');
 const scriptButton = document.createElement('button');
 const scrollButton = document.createElement('button');
 const sortListsButton = document.createElement('button');
+let chatTreeObserver = null;
 // Function to dynamically load KaTeX CSS and JS
 
 
@@ -205,15 +206,17 @@ function repeater() {
     }, 200); // ⏱️ Adjust as needed
 
     // Reload tree when navigating to a new conversation
-    const observer = new MutationObserver(() => {
-      const alreadyInjected = document.getElementById('chat-tree-panel');
-      const chatReady = document.querySelector('[data-testid^="conversation-turn-"]');
-      if (chatReady && !alreadyInjected) {
-        getNodes();
-      }
-    });
+    if (!chatTreeObserver) {
+      chatTreeObserver = new MutationObserver(() => {
+        const alreadyInjected = document.getElementById('chat-tree-panel');
+        const chatReady = document.querySelector('[data-testid^="conversation-turn-"]');
+        if (chatReady && !alreadyInjected) {
+          getNodes();
+        }
+      });
 
-    observer.observe(document.body, { childList: true, subtree: true });
+      chatTreeObserver.observe(document.body, { childList: true, subtree: true });
+    }
 
     if (isPaused) return; // Skip execution if paused
     try {
@@ -1581,6 +1584,8 @@ function getNodes() {
 
       content.appendChild(list);
       root.appendChild(content);
+      const existingPanel = document.getElementById('chat-tree-panel');
+      if (existingPanel) existingPanel.remove();
       document.body.appendChild(root);
 
       if (dragable) makeDraggable(root);


### PR DESCRIPTION
## Summary
- prevent multiple MutationObservers in HistorTreeNodes.js
- remove existing chat tree panel before inserting a new one

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6843ae16f2d4832fbb65edad0ccfde49